### PR TITLE
Add Debuggex link in tools

### DIFF
--- a/links.md
+++ b/links.md
@@ -61,6 +61,7 @@ Here is a compilation of links shared by the members of the [rigging-cfx france 
 * [Regex Cheat Sheet](https://www.rexegg.com/regex-quickstart.html)
 * [pdf.io](https://pdf.io/)
 * [Desmos - Graphing calculator](https://www.desmos.com/calculator)
+* [Debuggex - Regular Expression Visualizer](https://www.debuggex.com/)
 
 ## PSYCHOLOGY ##
 


### PR DESCRIPTION
Add link of a python/javascript regular expression visualizer in the tools category. This tool allow to generate a graph of what the regular expression is doing.